### PR TITLE
fix: user password not returned in GET routes

### DIFF
--- a/src/modules/users/schemas/users.schema.ts
+++ b/src/modules/users/schemas/users.schema.ts
@@ -24,6 +24,7 @@ export class User extends Document {
     type: String,
     required: true,
     description: 'Doit être une chaîne de caractères',
+    select: false,
   })
   password: string;
 

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -39,29 +39,20 @@ describe('UsersController', () => {
   });
 
   describe('getAllUser', () => {
-    it('should return all users', async () => {
+    it('should return all users without passwords', async () => {
       const mockUsers = {
         users: [
-          {
-            id: 1,
-            username: 'user1',
-            password: 'pass1',
-            firstname: 'first1',
-            lastname: 'last1',
-          },
-          {
-            id: 2,
-            username: 'user2',
-            password: 'pass2',
-            firstname: 'first2',
-            lastname: 'last2',
-          },
+          { id: 1, username: 'user1', password: 'pass1', firstname: 'first1', lastname: 'last1' },
+          { id: 2, username: 'user2', password: 'pass2', firstname: 'first2', lastname: 'last2' },
         ],
       };
       mockUsersService.findAll.mockResolvedValue(mockUsers);
 
       const result = await controller.getAllUser(1);
-      expect(result).toEqual(mockUsers);
+      expect(result).toEqual([
+        { id: 1, username: 'user1', firstname: 'first1', lastname: 'last1' },
+        { id: 2, username: 'user2', firstname: 'first2', lastname: 'last2' },
+      ]);
       expect(mockUsersService.findAll).toHaveBeenCalledWith(1);
     });
 
@@ -78,7 +69,7 @@ describe('UsersController', () => {
 
   describe('getOneUser', () => {
     it('should return a single user', async () => {
-      const mockUser = { id: 1, username: 'user1', password: 'pass1' };
+      const mockUser = { id: 1, username: 'user1', firstname: 'first1', lastname: 'last1' };
       mockUsersService.findById.mockResolvedValue(mockUser);
 
       const result = await controller.getOneUser(1, 1);
@@ -212,5 +203,7 @@ describe('UsersController', () => {
         HttpException,
       );
     });
+
+
   });
 });

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -42,8 +42,20 @@ describe('UsersController', () => {
     it('should return all users without passwords', async () => {
       const mockUsers = {
         users: [
-          { id: 1, username: 'user1', password: 'pass1', firstname: 'first1', lastname: 'last1' },
-          { id: 2, username: 'user2', password: 'pass2', firstname: 'first2', lastname: 'last2' },
+          {
+            id: 1,
+            username: 'user1',
+            password: 'pass1',
+            firstname: 'first1',
+            lastname: 'last1',
+          },
+          {
+            id: 2,
+            username: 'user2',
+            password: 'pass2',
+            firstname: 'first2',
+            lastname: 'last2',
+          },
         ],
       };
       mockUsersService.findAll.mockResolvedValue(mockUsers);
@@ -69,7 +81,12 @@ describe('UsersController', () => {
 
   describe('getOneUser', () => {
     it('should return a single user', async () => {
-      const mockUser = { id: 1, username: 'user1', firstname: 'first1', lastname: 'last1' };
+      const mockUser = {
+        id: 1,
+        username: 'user1',
+        firstname: 'first1',
+        lastname: 'last1',
+      };
       mockUsersService.findById.mockResolvedValue(mockUser);
 
       const result = await controller.getOneUser(1, 1);
@@ -203,7 +220,5 @@ describe('UsersController', () => {
         HttpException,
       );
     });
-
-
   });
 });

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -40,9 +40,9 @@ export class UsersController {
       if (!users || users.length === 0) {
         throw new NotFoundException();
       }
-      return users.users.map(({ password, ...user }) => user);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      return users.map(({ password, ...user }) => user);
     } catch (error) {
-      console.error(error);
       if (error instanceof HttpException) {
         throw error;
       }
@@ -77,6 +77,7 @@ export class UsersController {
       if (!user) {
         throw new NotFoundException();
       }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { password, ...userWithoutPassword } = user;
       return userWithoutPassword;
     } catch (error) {

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -41,7 +41,7 @@ export class UsersController {
         throw new NotFoundException();
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      return users.map(({ password, ...user }) => user);
+      return users.users.map(({ password, ...user }) => user);
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -40,8 +40,9 @@ export class UsersController {
       if (!users || users.length === 0) {
         throw new NotFoundException();
       }
-      return users;
+      return users.users.map(({ password, ...user }) => user);
     } catch (error) {
+      console.error(error);
       if (error instanceof HttpException) {
         throw error;
       }
@@ -76,7 +77,8 @@ export class UsersController {
       if (!user) {
         throw new NotFoundException();
       }
-      return user;
+      const { password, ...userWithoutPassword } = user;
+      return userWithoutPassword;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;


### PR DESCRIPTION
## Describe your changes
User password should not be returned in GET routes
## How to test the feature
Check the response on the GET routes /users and /users/{id}. The password should not appear'
## Issue ticket number and link
Closes #118 
## Checklist before requesting a review
- [x My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
