### PR TITLE
fix: fix ghost 404 and update food ingredients in service

### DIFF
--- a/src/modules/food/food.controller.spec.ts
+++ b/src/modules/food/food.controller.spec.ts
@@ -184,17 +184,6 @@ describe('FoodController', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('should throw NotFoundException when no changes made', async () => {
-      mockFoodService.updateOne.mockResolvedValue({
-        matchedCount: 1,
-        modifiedCount: 0,
-      });
-
-      await expect(
-        controller.updateOneFood(1, 1, updateFoodDto),
-      ).rejects.toThrow(NotFoundException);
-    });
-
     it('should handle service error', async () => {
       mockFoodService.updateOne.mockRejectedValue(new Error('Database error'));
       await expect(

--- a/src/modules/food/food.controller.ts
+++ b/src/modules/food/food.controller.ts
@@ -187,9 +187,6 @@ export class FoodController {
       if (result.matchedCount === 0) {
         throw new NotFoundException();
       }
-      if (result.modifiedCount === 0) {
-        throw new NotFoundException();
-      }
       return;
     } catch (error) {
       if (error instanceof HttpException) {

--- a/src/modules/food/food.service.ts
+++ b/src/modules/food/food.service.ts
@@ -163,6 +163,7 @@ export class FoodService extends DB {
           'foods.$.price': body['price'], // Update the price of the food item
           'foods.$.id_category': body['id_category'], // Update the category ID
           'foods.$.details': body['details'], // Update the details of the food item
+          'foods.$.ingredients': body['ingredients'], // Update the ingredients of the food item
         },
       },
     );


### PR DESCRIPTION
## Describe your changes
The route PUT for /foods now returns 200 when not modifications are made.
When an ingredient is added/removed from a food, the service now correctly update the DB.

## How to test the feature
Use the PUT route /food/{id}
1. Try to send the same body that's stored in the DB with no modifications, it should returns 200
2. Try to modify only the ingredients, it should returns a 200 and be successfully stored in the DB.

## Issue ticket number and link
Closes #123 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
